### PR TITLE
Remove excess "@" character if present in domain

### DIFF
--- a/import.rb
+++ b/import.rb
@@ -2,8 +2,8 @@
 
 require "fileutils"
 
-ARGF.each_with_index do |line, idx|
-  parts = line.strip.split(".").reverse
+ARGF.each do |line|
+  parts = line.strip.delete_prefix('@').split(".").reverse
   name = parts.pop
   dirs = parts.join("/")
   path = "#{File.expand_path(__FILE__+'/..')}/lib/domains/#{dirs}"


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1hDS1tk1cwPPfH2y3pE5baggy1gjmiAIzDGccPNqbNVQ/edit?ts=5a8d899a#gid=0 tends to have the `@` character in front of domains, so let's remove it if it's there.