### PR TITLE
Update import.rb to use SWOT for acccuracy.

### DIFF
--- a/import.rb
+++ b/import.rb
@@ -1,16 +1,16 @@
 #!/usr/bin/env ruby
 
 require "fileutils"
+require "./lib/swot.rb"
 
 ARGF.each do |line|
-  parts = line.strip.delete_prefix('@').split(".").reverse
-  name = parts.pop
-  dirs = parts.join("/")
-  path = "#{File.expand_path(__FILE__+'/..')}/lib/domains/#{dirs}"
-  if File.exist?("#{path}/#{name}.txt")
+  swot = Swot.new(line.strip)
+  file_path = swot.send(:file_path)
+
+  if File.exist?(file_path)
     next
   else
-    FileUtils.mkdir_p path
-    File.open("#{path}/#{name}.txt", "w") { |f| f.puts(name) }
+    FileUtils.mkdir_p Swot::domains_path
+    File.open(file_path, "w") { |f| f.puts(swot.domain.domain.split('.').first) }
   end
 end


### PR DESCRIPTION
SWOT only uses the "domain" value of the host given to verify a domain 
as seen here:

https://github.com/mubi/swot/blob/master/lib/swot.rb#L91

Using the private Swot#file_path method in import.rb, we can save the 
domain correctly to our list by reverse engineering the SWOT library.